### PR TITLE
Criando templates para paginas reusaveis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="https://maven.apache.org/POM/4.0.0" 
-         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -76,12 +76,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity5</artifactId>
         </dependency>
-        
+
+        <dependency>
+            <groupId>nz.net.ultraq.thymeleaf</groupId>
+            <artifactId>thymeleaf-layout-dialect</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/src/main/java/br/com/prontomed/peg/configs/ThymeleafConfig.java
+++ b/src/main/java/br/com/prontomed/peg/configs/ThymeleafConfig.java
@@ -1,0 +1,15 @@
+package br.com.prontomed.peg.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import nz.net.ultraq.thymeleaf.LayoutDialect;
+
+@Configuration
+public class ThymeleafConfig {
+    
+    @Bean
+    public LayoutDialect layoutDialect() {
+        return new LayoutDialect();
+    }
+}

--- a/src/main/resources/templates/layouts/default.html
+++ b/src/main/resources/templates/layouts/default.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+
+<head>
+    <title>Default Layout</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta content="ie=edge" http-equiv="x-ua-compatible" />
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
+        crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" th:href="@{/css/css.css}" />
+</head>
+
+<body>
+    <div class="container">
+        <div layout:fragment="content"></div>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+        integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+        integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
+        crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
+        integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
+        crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,42 +1,34 @@
 <!doctype html>
-<html lang="pt-br"
-      xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org">
-    <head>
-        <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-                <!-- CSS Bootstrap -->
-                <link rel="stylesheet" href="bootstrap/css/bootstrap-reboot.min.css">
-                    <link rel="stylesheet" href="css/css.css">
-                        <title>Login</title>
-                        </head>
-                        <body id="fundologin">
-                            <div class="card" id="telalogin">
-                                <!-- <img src="..." class="card-img-top" alt="..."> -->
-                                <div class="card-body">
-                                    <form th:action="@{/login}" method="POST">
-                                        <div class="form-group">
-                                            <h3 class="text-primary">Bem-vindo</h3>
-                                            <h4>Acesse sua conta</h4>
-                                            </br>
-                                            <label>CPF</label>
-                                            <input class="form-control" name="user_name" id="user_name" aria-describedby="emailHelp" placeholder="Informe seu cpf">
-                                        </div>
-                                        <div class="form-group">
-                                            <label>Senha</label>
-                                            <input type="password" name="password" class="form-control" id="password" placeholder="Insira sua senha">
-                                        </div>
-                                        <button type="submit" class="btn btn-primary btn-block" >Entrar</button>
-                                    </form>
-                                    <form th:action="@{/cadastro}" method="get">
-                                        <button type="submit" class="btn btn-secondary btn-block" >Cadastre-se grátis</button>
-                                    </form>
-                                </div>
-                            </div>
-                            <!-- Javascript Opcional -->
-                            <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-                            <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-                            <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-                            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-                        </body>
-                        </html>
+<html lang="pt-br" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/default}">
+
+<head>
+    <title>Login</title>
+</head>
+
+<body>
+    <div id="fundologin" layout:fragment="content">
+        <div class="card" id="telalogin">
+            <div class="card-body">
+                <form th:action="@{/login}" method="POST">
+                    <div class="form-group">
+                        <h3 class="text-primary">Bem-vindo</h3>
+                        <h4>Acesse sua conta</h4>
+                        </br>
+                        <label>CPF</label>
+                        <input class="form-control" name="user_name" id="user_name" aria-describedby="emailHelp" placeholder="Informe seu cpf">
+                    </div>
+                    <div class="form-group">
+                        <label>Senha</label>
+                        <input type="password" name="password" class="form-control" id="password" placeholder="Insira sua senha">
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-block">Entrar</button>
+                </form>
+                <form th:action="@{/cadastro}" method="get">
+                    <button type="submit" class="btn btn-secondary btn-block">Cadastre-se grátis</button>
+                </form>
+            </div>
+        </div>
+</body>
+
+</html>


### PR DESCRIPTION
fix #22 

Agora podemos usar templates bases para as páginas. Por exemplo, no template "default.html", eu coloquei os metadados padrão e CSSs dentro da tag <head>, assim como importações de JS no fim da página. Assim, a página "login.html" fica com <head> bem simples, sem precisar importar qualquer CSS ou JS.